### PR TITLE
Always use default ports for *sending* NetBIOS messages

### DIFF
--- a/src/main/java/org/filesys/netbios/NetBIOSDatagramSocket.java
+++ b/src/main/java/org/filesys/netbios/NetBIOSDatagramSocket.java
@@ -136,7 +136,7 @@ public class NetBIOSDatagramSocket {
             throws IOException {
 
         //	Create a datagram packet using the NetBIOS datagram buffer
-        DatagramPacket pkt = new DatagramPacket(dgram.getBuffer(), dgram.getLength(), destAddr, destPort);
+        DatagramPacket pkt = new DatagramPacket(dgram.getBuffer(), dgram.getLength(), destAddr, RFCNetBIOSProtocol.DATAGRAM);
 
         //	Send the NetBIOS datagram
         m_socket.send(pkt);
@@ -152,7 +152,7 @@ public class NetBIOSDatagramSocket {
             throws IOException {
 
         //	Create a datagram packet using the NetBIOS datagram buffer
-        DatagramPacket pkt = new DatagramPacket(dgram.getBuffer(), dgram.getLength(), m_broadcastAddr, m_defPort);
+        DatagramPacket pkt = new DatagramPacket(dgram.getBuffer(), dgram.getLength(), m_broadcastAddr, RFCNetBIOSProtocol.DATAGRAM);
 
         //	Send the NetBIOS datagram
         m_socket.send(pkt);

--- a/src/main/java/org/filesys/netbios/server/NetBIOSNameServer.java
+++ b/src/main/java/org/filesys/netbios/server/NetBIOSNameServer.java
@@ -339,7 +339,7 @@ public class NetBIOSNameServer extends NetworkServer implements Runnable, Config
                         addPkt.setFlags(0);
 
                     //  Allocate the datagram packet, using the add name buffer
-                    DatagramPacket pkt = new DatagramPacket(buf, len, dest, getPort());
+                    DatagramPacket pkt = new DatagramPacket(buf, len, dest, RFCNetBIOSProtocol.NAMING);
 
                     //	Send the add name request
                     if (m_socket != null)
@@ -385,7 +385,7 @@ public class NetBIOSNameServer extends NetworkServer implements Runnable, Config
                         refreshPkt.setFlags(0);
 
                     //  Allocate the datagram packet, using the refresh name buffer
-                    DatagramPacket pkt = new DatagramPacket(buf, len, dest, getPort());
+                    DatagramPacket pkt = new DatagramPacket(buf, len, dest, RFCNetBIOSProtocol.NAMING);
 
                     //	Send the refresh name request
                     if (m_socket != null)
@@ -430,7 +430,7 @@ public class NetBIOSNameServer extends NetworkServer implements Runnable, Config
                         delPkt.setFlags(0);
 
                     //  Allocate the datagram packet, using the add name buffer
-                    DatagramPacket pkt = new DatagramPacket(buf, len, dest, getPort());
+                    DatagramPacket pkt = new DatagramPacket(buf, len, dest, RFCNetBIOSProtocol.NAMING);
 
                     //	Send the add name request
                     if (m_socket != null)
@@ -1502,7 +1502,7 @@ public class NetBIOSNameServer extends NetworkServer implements Runnable, Config
             throws java.io.IOException {
 
         //  Allocate the datagram packet, using the add name buffer
-        DatagramPacket pkt = new DatagramPacket(nbpkt.getBuffer(), len, NetworkSettings.getBroadcastAddress(), getPort());
+        DatagramPacket pkt = new DatagramPacket(nbpkt.getBuffer(), len, NetworkSettings.getBroadcastAddress(), RFCNetBIOSProtocol.NAMING);
 
         //  Send the datagram packet
         m_socket.send(pkt);


### PR DESCRIPTION
The way I understand it, the ability to use a custom port is mainly relevant for listening (because you can't bind a socket to a port < 1023 without root on unixoid systems), and the documentation explicitly points out the scenario of configuring a non-privileged port and then use firewall rules to forward the network traffic to the unprivileged port.

In that case, it wouldn't make sense to use the same alternative ports as the destination port when sending out various broadcast messages, however this is exactly what currently happens.

We already hardcode e.g. the name server port when sending out a few messages ([e.g. here](https://github.com/FileSysOrg/jfileserver/blob/436386995d2ce1205c542924eb198a63711fe92b/src/main/java/org/filesys/netbios/NetBIOSSession.java#L621)), so I just propose completing that status and hardcode the remaining messages relevant for the name server and the host announcer, too.