### PR TITLE
Propagate broadcast mask into NetworkSettings when using the host announcer

### DIFF
--- a/src/main/java/org/filesys/smb/server/NetBIOSSessionSocketHandler.java
+++ b/src/main/java/org/filesys/smb/server/NetBIOSSessionSocketHandler.java
@@ -23,6 +23,7 @@ import java.net.InetAddress;
 import java.net.Socket;
 
 import org.filesys.debug.Debug;
+import org.filesys.netbios.NetworkSettings;
 import org.filesys.server.SocketSessionHandler;
 import org.filesys.server.config.ServerConfiguration;
 import org.filesys.smb.mailslot.TcpipNetBIOSHostAnnouncer;
@@ -140,6 +141,7 @@ public class NetBIOSSessionSocketHandler extends SocketSessionHandler {
 
 			try {
 				announcer.setBroadcastAddress(smbConfig.getBroadcastMask());
+				NetworkSettings.setBroadcastMask(smbConfig.getBroadcastMask());
 			}
 			catch (Exception ex) {
 			}

--- a/src/main/java/org/filesys/smb/server/ThreadedSMBConnectionsHandler.java
+++ b/src/main/java/org/filesys/smb/server/ThreadedSMBConnectionsHandler.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.filesys.debug.Debug;
+import org.filesys.netbios.NetworkSettings;
 import org.filesys.server.SessionHandlerInterface;
 import org.filesys.server.SessionHandlerList;
 import org.filesys.server.SocketSessionHandler;
@@ -127,6 +128,7 @@ public class ThreadedSMBConnectionsHandler implements SMBConnectionsHandler {
 
 					try {
 						announcer.setBroadcastAddress(config.getBroadcastMask());
+						NetworkSettings.setBroadcastMask(config.getBroadcastMask());
 					}
 					catch (Exception ex) {
 					}


### PR DESCRIPTION
The NetBIOSDatagramSocket actually retrieves its broadcast adress from the NetworkSettings class, so if we've been given an explicit broadcast mask in the general server configuration, use that instead of the falling back to the GenerateBroadcastMask function, which still assumes classful addressing and therefore is prone to producing nonsense.