### PR TITLE
Abort sending AddName/Refresh requests when the server is shutting down

### DIFF
--- a/src/main/java/org/filesys/netbios/server/NetBIOSNameServer.java
+++ b/src/main/java/org/filesys/netbios/server/NetBIOSNameServer.java
@@ -724,7 +724,7 @@ public class NetBIOSNameServer extends NetworkServer implements Runnable, Config
             throw new IOException("NetBIOS name socket not initialized");
 
         //	Create an add name request and add to the request list
-        NetBIOSRequest nbReq = new NetBIOSRequest(NetBIOSRequest.Type.ADD_NAME, name, getNextTransactionId());
+        NetBIOSRequest nbReq = new NetBIOSRequest(NetBIOSRequest.Type.ADD_NAME, name, getNextTransactionId(), AddNameRetries);
 
         //	Set the retry interval
         if (hasPrimaryWINSServer())


### PR DESCRIPTION
Registering three names (the same host both as workstation and server, plus the workgroup name) with five retries each at two second intervals takes 30 seconds, and with more names to announce it'd only get worse.

Right now, if the server is being shut down shortly after having been started, we have to wait for all those AddName requests to be processes, which seems a bit pointless.