### PR TITLE
Fix #18 – Last modified date isn't preserved when copying file to file share

### DIFF
--- a/src/main/java/org/filesys/server/filesys/NetworkFile.java
+++ b/src/main/java/org/filesys/server/filesys/NetworkFile.java
@@ -118,6 +118,9 @@ public abstract class NetworkFile {
     protected long m_modifyDate;
     protected long m_accessDate;
 
+    // Track whether file date needs updating on file close
+    protected boolean m_modifyDateDirty;
+
     // Granted file access type
     protected Access m_grantedAccess;
 
@@ -567,6 +570,17 @@ public abstract class NetworkFile {
     }
 
     /**
+     * Return whether the file modify date/time is dirty due to file writes. Calling
+     * {@link incrementWriteCount} marks the modify date/time as dirty, setting the
+     * date/time via {@link setModifyDate} resets it back to clean.
+     *
+     * @return boolean
+     */
+    public final boolean isModifyDateDirty() {
+    	return m_modifyDateDirty;
+    }
+
+    /**
      * Get the write count for the file
      *
      * @return int
@@ -580,6 +594,7 @@ public abstract class NetworkFile {
      */
     public final void incrementWriteCount() {
         m_writeCount++;
+        m_modifyDateDirty = true;
     }
 
     /**
@@ -799,6 +814,7 @@ public abstract class NetworkFile {
      */
     public final void setModifyDate(long dattim) {
         m_modifyDate = dattim;
+        m_modifyDateDirty = false;
     }
 
     /**

--- a/src/main/java/org/filesys/server/filesys/db/DBDiskDriver.java
+++ b/src/main/java/org/filesys/server/filesys/db/DBDiskDriver.java
@@ -1488,8 +1488,12 @@ public class DBDiskDriver implements DiskInterface, DiskSizeInterface, DiskVolum
             if (info.hasSetFlag(FileInfo.SetCreationDate))
                 dbInfo.setAccessDateTime(info.getCreationDateTime());
 
-            if (info.hasSetFlag(FileInfo.SetModifyDate))
-                dbInfo.setAccessDateTime(info.getModifyDateTime());
+            if (info.hasSetFlag(FileInfo.SetModifyDate)) {
+                long modifyDate = info.getModifyDateTime();
+                dbInfo.setAccessDateTime(modifyDate);
+                if (info.hasNetworkFile())
+                    info.getNetworkFile().setModifyDate(modifyDate);
+            }
 
             if (info.hasSetFlag(FileInfo.SetChangeDate))
                 dbInfo.setAccessDateTime(info.getChangeDateTime());

--- a/src/main/java/org/filesys/server/filesys/db/LocalDataNetworkFile.java
+++ b/src/main/java/org/filesys/server/filesys/db/LocalDataNetworkFile.java
@@ -244,8 +244,11 @@ public class LocalDataNetworkFile extends DBNetworkFile {
             m_io = null;
 
             //	Set the last modified date/time for the file
-            if (this.getWriteCount() > 0)
-                m_file.setLastModified(System.currentTimeMillis());
+            if (this.isModifyDateDirty()) {
+                long curTime = System.currentTimeMillis();
+                m_file.setLastModified(curTime);
+                this.setModifyDate(curTime);
+            }
 
             //	Set the new file size
             setFileSize(m_file.length());

--- a/src/main/java/org/filesys/server/filesys/pseudo/PseudoNetworkFile.java
+++ b/src/main/java/org/filesys/server/filesys/pseudo/PseudoNetworkFile.java
@@ -97,8 +97,11 @@ public class PseudoNetworkFile extends NetworkFile implements NetworkFileStateIn
             m_io = null;
 
             // Set the last modified date/time for the file
-            if (this.getWriteCount() > 0)
-                m_file.setLastModified(System.currentTimeMillis());
+            if (this.isModifyDateDirty()) {
+                long curTime = System.currentTimeMillis();
+                m_file.setLastModified(curTime);
+                this.setModifyDate(curTime);
+            }
 
             // Indicate that the file is closed
             setClosed(true);

--- a/src/main/java/org/filesys/smb/server/CoreProtocolHandler.java
+++ b/src/main/java/org/filesys/smb/server/CoreProtocolHandler.java
@@ -2608,6 +2608,9 @@ class CoreProtocolHandler extends ProtocolHandler {
             // Access the disk interface that is associated with the shared device
             DiskInterface disk = (DiskInterface) conn.getSharedDevice().getInterface();
 
+            // Store the associated network file in the file information object
+            finfo.setNetworkFile(netFile);
+
             // Get the file information for the specified file/directory
             finfo.setFileInformationFlags(setFlags);
             disk.setFileInformation(m_sess, conn, netFile.getFullName(), finfo);

--- a/src/main/java/org/filesys/smb/server/disk/JavaNIODiskDriver.java
+++ b/src/main/java/org/filesys/smb/server/disk/JavaNIODiskDriver.java
@@ -855,6 +855,10 @@ public class JavaNIODiskDriver implements DiskInterface {
 
             //	Update the file/folder modify date/time
             Files.setLastModifiedTime( filePath, FileTime.fromMillis( info.getModifyDateTime()));
+
+            // Update the associated network file, too, if possible
+            if (info.hasNetworkFile())
+                info.getNetworkFile().setModifyDate(info.getModifyDateTime());
         }
     }
 

--- a/src/main/java/org/filesys/smb/server/disk/JavaNIONetworkFile.java
+++ b/src/main/java/org/filesys/smb/server/disk/JavaNIONetworkFile.java
@@ -130,8 +130,11 @@ public class JavaNIONetworkFile extends NetworkFile {
             m_io = null;
 
             //	Set the last modified date/time for the file
-            if (this.getWriteCount() > 0)
-                Files.setLastModifiedTime(m_path, FileTime.fromMillis( System.currentTimeMillis()));
+            if (this.isModifyDateDirty()) {
+                long curTime = System.currentTimeMillis();
+                Files.setLastModifiedTime(m_path, FileTime.fromMillis(curTime));
+                this.setModifyDate(curTime);
+            }
 
             //	Indicate that the file is closed
             setClosed(true);

--- a/src/main/java/org/filesys/smb/server/disk/original/JavaFileDiskDriver.java
+++ b/src/main/java/org/filesys/smb/server/disk/original/JavaFileDiskDriver.java
@@ -810,6 +810,10 @@ public class JavaFileDiskDriver implements DiskInterface {
             //	Update the file/folder modify date/time
             File file = new File(fname);
             file.setLastModified(info.getModifyDateTime());
+
+            // Update the associated network file, too, if possible
+            if (info.hasNetworkFile())
+                info.getNetworkFile().setModifyDate(info.getModifyDateTime());
         }
     }
 

--- a/src/main/java/org/filesys/smb/server/disk/original/JavaNetworkFile.java
+++ b/src/main/java/org/filesys/smb/server/disk/original/JavaNetworkFile.java
@@ -198,8 +198,11 @@ public class JavaNetworkFile extends NetworkFile {
             m_io = null;
 
             //	Set the last modified date/time for the file
-            if (this.getWriteCount() > 0)
-                m_file.setLastModified(System.currentTimeMillis());
+            if (this.isModifyDateDirty()) {
+                long curTime = System.currentTimeMillis();
+                m_file.setLastModified(curTime);
+                this.setModifyDate(curTime);
+            }
 
             //	Indicate that the file is closed
             setClosed(true);


### PR DESCRIPTION
This is a tentative fix for issue #18.

The idea is to track the dirty state of the last modified date via a boolean on the `NetworkFile`, so incrementing the write counter sets the flag to dirty and manually updating the last modified date sets it back to clean, and then on file close the last modified date is only automatically updated if it's marked as dirty.

It's not completely perfect, because it seems that depending on the caller it's not always possible to retrieve the corresponding `NetworkFile` from inside a `DiskInterface.setFileinformation`, and therefore reset the tracking flag back to clean, but at least for SMB traffic from a Windows client it seems to work fine.