### PR TITLE
Fix files missing from large directories

### DIFF
--- a/src/main/java/org/filesys/server/filesys/FileInfo.java
+++ b/src/main/java/org/filesys/server/filesys/FileInfo.java
@@ -639,6 +639,7 @@ public class FileInfo {
 	 */
 	public final void resetInfo() {
 		m_name = "";
+		m_shortName = null;
 		m_path = null;
 
 		m_size = 0L;
@@ -666,6 +667,7 @@ public class FileInfo {
 	 */
 	public final void copyFrom(FileInfo finfo) {
 		m_name = finfo.getFileName();
+		m_shortName = finfo.getShortName();
 		m_path = finfo.getPath();
 
 		m_size = finfo.getSize();

--- a/src/main/java/org/filesys/smb/server/disk/JavaNIOSearchContext.java
+++ b/src/main/java/org/filesys/smb/server/disk/JavaNIOSearchContext.java
@@ -438,7 +438,8 @@ public class JavaNIOSearchContext extends SearchContext {
             while ( curPath != null && restartOK == false) {
 
                 if ( curPath.getFileName().toString().equalsIgnoreCase(info.getFileName())) {
-                    restartOK = true;
+                    // Rewind by one, so the next call to nextFileInfo will return the correct item
+                    restartOK = restartAt(m_idx - 1);
                 }
                 else {
                     curPath = m_pathIter.next();

--- a/src/main/java/org/filesys/smb/server/disk/JavaNIOSearchContext.java
+++ b/src/main/java/org/filesys/smb/server/disk/JavaNIOSearchContext.java
@@ -411,6 +411,7 @@ public class JavaNIOSearchContext extends SearchContext {
 
         // Restart the iteration and skip to the required position
         try {
+            m_stream.close();
             m_stream = Files.newDirectoryStream(m_root);
             m_pathIter = m_stream.iterator();
         }
@@ -452,6 +453,7 @@ public class JavaNIOSearchContext extends SearchContext {
             resetIndex();
 
             try {
+                m_stream.close();
                 m_stream = Files.newDirectoryStream(m_root);
                 m_pathIter = m_stream.iterator();
             }
@@ -513,4 +515,19 @@ public class JavaNIOSearchContext extends SearchContext {
         if (m_relPath != null && m_relPath.endsWith(FileName.DOS_SEPERATOR_STR) == false)
             m_relPath = m_relPath + FileName.DOS_SEPERATOR_STR;
     }
+
+    /**
+     * Close the search.
+     */
+    public void closeSearch() {
+        if (m_stream != null) {
+            try {
+                m_stream.close();
+            }
+            catch (IOException unused) {
+            }
+        }
+        super.closeSearch();
+    }
+
 }


### PR DESCRIPTION
In large directories I've observed that a number of files are missing on jfileserver shares. After some more investigation, it turned out that the missing files correspond to FIND_NEXT2 requests – the first file from every FIND_NEXT2 response is missing. (And I suspect that SMB2/3 would be similarly affected if a search needs to be split up into multiple request/reponse pairs.)

Fixing this issue in turn exacerbates an existing performance issue in the `restartAt(FileInfo)` code in `JavaNIOSearchContext`. Due to the way our search and SMB APIs are structured, when we need to split up a large search response (with lots of files) into multiple packets, at the boundary between each packet we need to retrieve the FileInfo object for the same file twice - once to find out that it doesn't fit into the previous packet anymore, and a second time to actually transmit it in the followup packet.

Because the NIO directory iterator cannot be rewound to go back by one entry, this means that we have to iterate through the whole directory up to the target file again, and due to the fix for the above we actually need to do it twice now.

To fix the resulting performance issue in large directories (where on a phone and with a few thousand files a single FIND_FIRST/NEXT2 call can take hundreds of ms and return usually at most ~100 files), I propose special-casing this common scenario of restarting the SearchContext by exactly one entry earlier.