### PR TITLE
Configuration improvements for removing servers

### DIFF
--- a/src/main/java/org/filesys/server/NetworkServerList.java
+++ b/src/main/java/org/filesys/server/NetworkServerList.java
@@ -20,6 +20,7 @@
 package org.filesys.server;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -27,7 +28,7 @@ import java.util.List;
  *
  * @author gkspencer
  */
-public class NetworkServerList {
+public class NetworkServerList implements Iterable<NetworkServer> {
 
     //	List of network servers
     private List<NetworkServer> m_servers;
@@ -37,6 +38,14 @@ public class NetworkServerList {
      */
     public NetworkServerList() {
         m_servers = new ArrayList<NetworkServer>();
+    }
+
+    /**
+     * Iterator over the servers in the list
+     */
+    @Override
+    public final Iterator<NetworkServer> iterator() {
+        return m_servers.iterator();
     }
 
     /**

--- a/src/main/java/org/filesys/server/config/ServerConfiguration.java
+++ b/src/main/java/org/filesys/server/config/ServerConfiguration.java
@@ -159,6 +159,13 @@ public class ServerConfiguration implements ServerConfigurationAccessor {
     }
 
     /**
+     * Remove all active servers
+     */
+    public final void removeAllServers() {
+        m_serverList.removeAll();
+    }
+
+    /**
      * Return the number of active servers
      *
      * @return int

--- a/src/main/java/org/filesys/server/config/ServerConfiguration.java
+++ b/src/main/java/org/filesys/server/config/ServerConfiguration.java
@@ -155,13 +155,22 @@ public class ServerConfiguration implements ServerConfigurationAccessor {
      * @return NetworkServer
      */
     public final NetworkServer removeServer(String proto) {
-        return m_serverList.removeServer(proto);
+        final NetworkServer server = m_serverList.removeServer(proto);
+        if (server instanceof ConfigurationListener) {
+            removeListener((ConfigurationListener) server);
+        }
+        return server;
     }
 
     /**
      * Remove all active servers
      */
     public final void removeAllServers() {
+        for (NetworkServer server : m_serverList) {
+            if (server instanceof ConfigurationListener) {
+                removeListener((ConfigurationListener) server);
+            }
+        }
         m_serverList.removeAll();
     }
 


### PR DESCRIPTION
1. Wire up `NetworkServerList`'s existing method for removing *all* servers again from the configuration.
2. Avoid leaking servers via their `ConfigurationListener`s when removing them.