### PR TITLE
Trashcan folder "same volume" check is too restrictive

### DIFF
--- a/src/main/java/org/filesys/smb/server/disk/JavaNIODeviceContext.java
+++ b/src/main/java/org/filesys/smb/server/disk/JavaNIODeviceContext.java
@@ -123,7 +123,8 @@ public class JavaNIODeviceContext extends DiskDeviceContext {
                     throw new DeviceContextException("Trashcan path is not a folder - " + m_trashDir.getAbsolutePath());
 
                 // Make sure the trashcan folder is on the same volume as the shared folder, so we can rename deleted files
-                if ( rootDir.getParent().equalsIgnoreCase( m_trashDir.getParent()) == false) {
+                if (!m_trashDir.getAbsolutePath().startsWith(rootDir.getAbsolutePath())
+                        && !rootDir.getParent().equalsIgnoreCase(m_trashDir.getParent())) {
 
                     // File share and trash folders are not on the same volume
                     throw new DeviceContextException("File share and trash folders must be on the same volume");

--- a/src/main/java/org/filesys/smb/server/disk/JavaNIODeviceContext.java
+++ b/src/main/java/org/filesys/smb/server/disk/JavaNIODeviceContext.java
@@ -123,8 +123,7 @@ public class JavaNIODeviceContext extends DiskDeviceContext {
                     throw new DeviceContextException("Trashcan path is not a folder - " + m_trashDir.getAbsolutePath());
 
                 // Make sure the trashcan folder is on the same volume as the shared folder, so we can rename deleted files
-                if (!m_trashDir.getAbsolutePath().startsWith(rootDir.getAbsolutePath())
-                        && !rootDir.getParent().equalsIgnoreCase(m_trashDir.getParent())) {
+                if (!isTrashcanOnSameVolume(rootDir, m_trashDir)) {
 
                     // File share and trash folders are not on the same volume
                     throw new DeviceContextException("File share and trash folders must be on the same volume");
@@ -168,6 +167,24 @@ public class JavaNIODeviceContext extends DiskDeviceContext {
             //	Local path not specified
             throw new DeviceContextException("LocalPath parameter not specified");
         }
+    }
+
+    /**
+     * Validate that the trashcan folder resides on the same volume as the shared
+     * folder. This is a requirement because we want to be able to move files into
+     * the trashcan by simply renaming them.
+     * <p>
+     * The default implementation only uses a simple heuristic, override this method
+     * to provide a more advanced platform-specific check if required.
+     *
+     * @param rootDir  The root directory of the shared folder
+     * @param trashCan The proposed trashcan directory
+     * @return True if the proposed trashcan directory is acceptable, false to
+     *         signal an error
+     */
+    protected boolean isTrashcanOnSameVolume(File rootDir, File trashCan) {
+        return trashCan.getAbsolutePath().startsWith(rootDir.getAbsolutePath())
+                || rootDir.getParent().equalsIgnoreCase(m_trashDir.getParent());
     }
 
     /**

--- a/src/main/java/org/filesys/smb/server/disk/JavaNIODiskDriver.java
+++ b/src/main/java/org/filesys/smb/server/disk/JavaNIODiskDriver.java
@@ -1025,7 +1025,7 @@ public class JavaNIODiskDriver implements DiskInterface {
             throws DeviceContextException {
 
         // Parse the configuration and return the device context for this share
-        JavaNIODeviceContext ctx = new JavaNIODeviceContext( shareName, args);
+        JavaNIODeviceContext ctx = createJavaNIODeviceContext(shareName, args);
 
         // If the trashcan folder is configured then check if there are any trash files left over from a previous
         // server run
@@ -1061,6 +1061,20 @@ public class JavaNIODiskDriver implements DiskInterface {
 
         // Return the device context
         return ctx;
+    }
+
+    /**
+     * Provide a new <code>JavaNIODeviceContext</code> for
+     * <code>createContext</code> Override this method to provide your own class.
+     *
+     * @param shareName
+     * @param args
+     * @return DeviceContext
+     * @throws DeviceContextException Error creating the device context
+     */
+    protected JavaNIODeviceContext createJavaNIODeviceContext(String shareName, ConfigElement args)
+            throws DeviceContextException {
+        return new JavaNIODeviceContext(shareName, args);
     }
 
     /**


### PR DESCRIPTION
If I'm understanding it right, the current "Make sure the trashcan folder is on the same volume as the shared folder, so we can rename deleted files" check basically only allows siblings of the shared folder when setting a custom trashcan path.

In my opinion, this is
a) unnecessarily restrictive and
b) doesn't even guarantee that the two folders actually are residing on the same volume, because what with mountpoints, filesytem junctions, symbolic links and what not any two folders in an arbitrary relationship to each other could reside on completely different volumes.

Unfortunately the one proper solution I've quickly stumbled upon seems to be Android-specific (Android has added Java APIs for calling fstat), so for now I'd just suggest perhaps relaxing the check a bit (allowing child folders by default, too), plus adding a hook to allow overriding the check by implementors.