### PR TITLE
Make choice of OpenFileMap to be used configurable

### DIFF
--- a/src/main/java/org/filesys/app/SMBOnlyXMLServerConfiguration.java
+++ b/src/main/java/org/filesys/app/SMBOnlyXMLServerConfiguration.java
@@ -573,6 +573,11 @@ public class SMBOnlyXMLServerConfiguration extends ServerConfiguration {
 		if ( findChildNode( "disableNIO", smb.getChildNodes()) != null)
 			smbConfig.setDisableNIOCode( true);
 		
+		// Check if the HashedOpenFileMap should be disabled (and ArrayOpenFileMap used
+		// instead)
+		if (findChildNode("disableHashedOpenFileMap", smb.getChildNodes()) != null)
+			smbConfig.setDisableHashedOpenFileMap(true);
+
 		// Check if a maximum virtual circuits per session limit has been specified
 		elem = findChildNode("virtualCircuits", smb.getChildNodes());
 		if ( elem != null) {

--- a/src/main/java/org/filesys/server/config/ConfigId.java
+++ b/src/main/java/org/filesys/server/config/ConfigId.java
@@ -85,6 +85,7 @@ public class ConfigId {
     public static final int SMBRequireSigning	= GroupSMB + 33;
     public static final int SMBSocketKeepAlive	= GroupSMB + 34;
 	public static final int SMBPacketsPerThreadRun = GroupSMB + 35;
+	public static final int SMBDisableHashedOFM = GroupSMB + 36;
 
 	// FTP server variables
 	public static final int FTPBindAddress 		= GroupFTP + 1;

--- a/src/main/java/org/filesys/server/filesys/ArrayOpenFileMap.java
+++ b/src/main/java/org/filesys/server/filesys/ArrayOpenFileMap.java
@@ -49,7 +49,7 @@ public class ArrayOpenFileMap extends OpenFileMap {
 
         @Override
         public boolean hasNext() {
-            while ( m_files[ m_nextId] == null && m_nextId < m_files.length)
+            while (m_nextId < m_files.length && m_files[m_nextId] == null)
                 m_nextId++;
 
             return m_nextId < m_files.length;
@@ -57,7 +57,7 @@ public class ArrayOpenFileMap extends OpenFileMap {
 
         @Override
         public Integer next() {
-            while ( m_files[ m_nextId] == null && m_nextId < m_files.length)
+            while (m_nextId < m_files.length && m_files[m_nextId] == null)
                 m_nextId++;
 
             if ( m_nextId < m_files.length)

--- a/src/main/java/org/filesys/smb/server/SMBConfigSection.java
+++ b/src/main/java/org/filesys/smb/server/SMBConfigSection.java
@@ -138,6 +138,9 @@ public class SMBConfigSection extends ConfigSection {
     // Per session virtual circuit limit
     private int m_virtualCircuitLimit = SMBV1VirtualCircuitList.DefMaxCircuits;
 
+    // Use ArrayOpenFileMap instead of HashedOpenFileMap
+    private boolean m_disableHashedOpenFileMap;
+
     //--------------------------------------------------------------------------------
     //  Win32 NetBIOS configuration
     //
@@ -653,6 +656,15 @@ public class SMBConfigSection extends ConfigSection {
      */
     public final boolean isNativeCodeDisabled() {
         return m_disableNativeCode;
+    }
+
+    /**
+     * Determine if the HashedOpenFileMap should be disabled
+     *
+     * @return boolean
+     */
+    public final boolean hasDisableHashedOpenFileMap() {
+        return m_disableHashedOpenFileMap;
     }
 
     /**
@@ -1493,6 +1505,24 @@ public class SMBConfigSection extends ConfigSection {
      * @param forestName String
      */
     public final void setForestName(String forestName) { m_forestName = forestName; }
+
+    /**
+     * Set the disable HashedOpenFileMap flag
+     *
+     * @param disableHashedOFM boolean
+     * @return int
+     * @throws InvalidConfigurationException Failed to set the disable
+     *                                       HashedOpenFileMap flag
+     */
+    public final int setDisableHashedOpenFileMap(boolean disableHashedOFM) throws InvalidConfigurationException {
+
+        // Inform listeners, validate the configuration change
+        int sts = fireConfigurationChange(ConfigId.SMBDisableHashedOFM, new Boolean(disableHashedOFM));
+        m_disableHashedOpenFileMap = disableHashedOFM;
+
+        // Return the change status
+        return sts;
+    }
 
     /**
      * Close the configuration section


### PR DESCRIPTION
On older Android versions the fact that (Concurrent)HashMap's `keySet()` now returns a `KeySetView` instead of a plain `Set` is problematic and unfortunately not covered by Google's desugaring mechanism's, either.

Since you've still got the old implementation lying around, I'd like to make its usage configurable.